### PR TITLE
fix: conform initialize response to MCP specification

### DIFF
--- a/JsonRpcHandler.cs
+++ b/JsonRpcHandler.cs
@@ -106,15 +106,15 @@ public class JsonRpcHandler
     {
         var capabilities = new
         {
-            name = "SQL Server MCP",
-            version = "1.0.0",
+            protocolVersion = "2025-11-25",
+            serverInfo = new
+            {
+                name = "SQL Server MCP",
+                version = "1.0.0"
+            },
             capabilities = new
             {
-                databases = true,
-                tables = true,
-                columns = true,
-                procedures = true,
-                queryExecution = true
+                tools = new { }
             }
         };
 


### PR DESCRIPTION
The HandleInitializeAsync method returned a non-standard response that caused MCP clients (e.g. Windsurf) to fail with "Failed to initialize server". The response lacked the required protocolVersion and serverInfo fields defined by the MCP spec.

Updated the response to include:
- protocolVersion: "2025-11-25"
- serverInfo with name and version
- capabilities with tools object